### PR TITLE
Make coord_proj() work with more recent versions of ggplot2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/hrbrmstr/ggalt/issues
 Encoding: UTF-8
 Depends:
     R (>= 3.0.0),
-    ggplot2 (>= 2.0.0)
+    ggplot2 (>= 2.2.0)
 Suggests:
     testthat,
     gridExtra,

--- a/R/coord_proj.r
+++ b/R/coord_proj.r
@@ -87,7 +87,7 @@ coord_proj <- function(proj=NULL, inverse = FALSE, degrees = TRUE,
     ellps.default = ellps.default,
     degrees = degrees,
     limits = list(x = xlim, y = ylim),
-    params= list()
+    params= list()        # parameters are encoded in the proj4 string
   )
 
 }
@@ -219,7 +219,14 @@ CoordProj <- ggproto("CoordProj", Coord,
   },
 
   render_axis_h = function(self, scale_details, theme) {
-    if (is.null(scale_details$x.major)) return(zeroGrob())
+    arrange <- scale_details$x.arrange %||% c("primary", "secondary")
+
+    if (is.null(scale_details$x.major)) {
+      return(list(
+        top = zeroGrob(),
+        bottom = zeroGrob()
+      ))
+    }
 
     x_intercept <- with(scale_details, data.frame(
       x = x.major,
@@ -227,11 +234,23 @@ CoordProj <- ggproto("CoordProj", Coord,
     ))
     pos <- self$transform(x_intercept, scale_details)
 
-    guide_axis(pos$x, scale_details$x.labels, "bottom", theme)
+    axes <- list(
+      bottom = guide_axis(pos$x, scale_details$x.labels, "bottom", theme),
+      top = guide_axis(pos$x, scale_details$x.labels, "top", theme)
+    )
+    axes[[which(arrange == "secondary")]] <- zeroGrob()
+    axes
   },
 
   render_axis_v = function(self, scale_details, theme) {
-    if (is.null(scale_details$y.major)) return(zeroGrob())
+    arrange <- scale_details$y.arrange %||% c("primary", "secondary")
+
+    if (is.null(scale_details$y.major)) {
+      return(list(
+        left = zeroGrob(),
+        right = zeroGrob()
+      ))
+    }
 
     x_intercept <- with(scale_details, data.frame(
       x = x.range[1],
@@ -239,7 +258,12 @@ CoordProj <- ggproto("CoordProj", Coord,
     ))
     pos <- self$transform(x_intercept, scale_details)
 
-    guide_axis(pos$y, scale_details$y.labels, "left", theme)
+    axes <- list(
+      left = guide_axis(pos$y, scale_details$y.labels, "left", theme),
+      right = guide_axis(pos$y, scale_details$y.labels, "right", theme)
+    )
+    axes[[which(arrange == "secondary")]] <- zeroGrob()
+    axes
   }
 
 )

--- a/man/geom_bkde.Rd
+++ b/man/geom_bkde.Rd
@@ -45,8 +45,8 @@ results.}
 \item{range.x}{vector containing the minimum and maximum values of x at which
 to compute the estimate. see \code{\link[KernSmooth]{bkde}} for details}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_bkde2d.Rd
+++ b/man/geom_bkde2d.Rd
@@ -59,8 +59,8 @@ estimation}
 
 \item{linemitre}{Line mitre limit (number greater than 1)}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_stateface.Rd
+++ b/man/geom_stateface.Rd
@@ -50,8 +50,8 @@ on discrete scales.}
 \item{check_overlap}{If \code{TRUE}, text that overlaps previous text in the
 same layer will not be plotted.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_xspline.Rd
+++ b/man/geom_xspline.Rd
@@ -38,8 +38,8 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_xspline2.Rd
+++ b/man/geom_xspline2.Rd
@@ -35,8 +35,8 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/stat_ash.Rd
+++ b/man/stat_ash.Rd
@@ -45,8 +45,8 @@ interval.}
 to \emph{( 1 - abs(i/m)^kopt(1) )i^kopt(2)}; (2,2)=biweight (default);
  (0,0)=uniform; (1,0)=triangle; (2,1)=Epanechnikov; (2,3)=triweight.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/stat_stepribbon.Rd
+++ b/man/stat_stepribbon.Rd
@@ -31,8 +31,8 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.
@@ -55,7 +55,8 @@ to the paired geom/stat.}
 Provides stairstep values for ribbon plots
 }
 \examples{
-df <- data.frame(x=1:10, y=x+10, ymin=x+7, ymax=x+12)
+x <- 1:10
+df <- data.frame(x=x, y=x+10, ymin=x+7, ymax=x+12)
 
 gg <- ggplot(df, aes(x, y))
 gg <- gg + geom_ribbon(aes(ymin=ymin, ymax=ymax),


### PR DESCRIPTION
This change fixes the "a 'grob' path must contain at least one 'grob' name" error reported in hrbrmstr/ggalt#23.  The warnings about "Ignoring unknown aesthetics" are not fixed by these changes; however, those warnings do not appear to prevent the maps from rendering correctly.
