### PR TITLE
Fix a typo in `stat_stepribbon` doc

### DIFF
--- a/R/stat-stepribbon.r
+++ b/R/stat-stepribbon.r
@@ -5,9 +5,9 @@
 #' @md
 #' @inheritParams ggplot2::geom_ribbon
 #' @param geom which geom to use; defaults to "`ribbon`"
-#' @param direction \code{hv} for horizontal-veritcal steps, `vh`` for
+#' @param direction `hv` for horizontal-veritcal steps, `vh` for
 #'   vertical-horizontal steps
-#' @references \url{https://groups.google.com/forum/?fromgroups=#!topic/ggplot2/9cFWHaH1CPs}
+#' @references [https://groups.google.com/forum/?fromgroups=#!topic/ggplot2/9cFWHaH1CPs]()
 #' @export
 #' @examples
 #' x <- 1:10

--- a/man/stat_stepribbon.Rd
+++ b/man/stat_stepribbon.Rd
@@ -47,7 +47,7 @@ rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
-\item{direction}{\code{hv} for horizontal-veritcal steps, `vh`` for
+\item{direction}{\code{hv} for horizontal-veritcal steps, \code{vh} for
 vertical-horizontal steps}
 
 \item{...}{other arguments passed on to \code{\link[=layer]{layer()}}. These are


### PR DESCRIPTION
The original document has an extra backtick in `vh`.