### PR TITLE
docs: update dodgedev documentation to pass cmd check with no warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggalt
 Title: Extra Coordinate Systems, 'Geoms', Statistical Transformations, Scales
     and Fonts for 'ggplot2'
-Version: 0.6.1
+Version: 0.6.2
 Maintainer: Bob Rudis <bob@rud.is>
 Authors@R: c(
       person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 
@@ -57,7 +57,7 @@ Imports:
     extrafont,
     tibble,
     plotly (>= 3.4.1)
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr
 Collate:
     'annotate_textp.r'

--- a/R/position-dodgev.R
+++ b/R/position-dodgev.R
@@ -1,4 +1,26 @@
-#' Vertically dodge position
+#' @title Vertically dodge position
+#' @param height numeric, height of vertical dodge, Default: NULL
+#' @examples
+#'
+#' if(interactive()){
+#'
+#' dat <- data.frame(
+#'   trt = c(LETTERS[1:5], "D"),
+#'   l = c(20, 40, 10, 30, 50, 40),
+#'   r = c(70, 50, 30, 60, 80, 70)
+#' )
+#'
+#' ggplot(dat, aes(y=trt, x=l, xend=r)) +
+#'  geom_dumbbell(size=3, color="#e3e2e1",
+#'                colour_x = "#5b8124", colour_xend = "#bad744",
+#'                dot_guide=TRUE, dot_guide_size=0.25,
+#'                position=position_dodgev(height=0.8)) +
+#'  labs(x=NULL, y=NULL, title="ggplot2 geom_dumbbell with dot guide") +
+#'  theme_minimal() +
+#'  theme(panel.grid.major.x=element_line(size=0.05))
+#'
+#'  }
+#'
 #' @rdname position-dodgev
 #' @author @@ggstance authors
 #' @note position-dodgev(): unmodified from lionel-/ggstance/R/position-dodgev.R 73f521384ae8ea277db5f7d5a2854004aa18f947
@@ -8,8 +30,6 @@ position_dodgev <- function(height = NULL) {
 }
 
 #' @rdname position-dodgev
-#' @author @@ggstance authors
-#' @note PositionDodgev(): based on from lionel-/ggstance/R/position-dodgev.R 73f521384ae8ea277db5f7d5a2854004aa18f947
 #' @format NULL
 #' @usage NULL
 #' @export
@@ -29,9 +49,6 @@ PositionDodgev <- ggplot2::ggproto("PositionDodgev", ggplot2::Position,
                                    }
 )
 
-#' @rdname position-dodgev
-#' @author @@ggstance authors
-#' @note pos_dodgev(): unmodified from lionel-/ggstance/R/position-dodgev.R 73f521384ae8ea277db5f7d5a2854004aa18f947
 pos_dodgev <- function(df, height) {
   n <- length(unique(df$group))
   if (n == 1) return(df)
@@ -58,9 +75,6 @@ pos_dodgev <- function(df, height) {
   df
 }
 
-#' @rdname position-dodgev
-#' @author @@ggstance authors
-#' @note collidev(): based on lionel-/ggstance/R/position.R 73f521384ae8ea277db5f7d5a2854004aa18f947
 collidev <- function(data, height = NULL, name, strategy, ..., check.height = TRUE, reverse = FALSE) {
   # Determine height
   if (!is.null(height)) {

--- a/man/annotation_ticks.Rd
+++ b/man/annotation_ticks.Rd
@@ -5,9 +5,9 @@
 \title{Annotation: tick marks}
 \usage{
 annotation_ticks(sides = "b", scale = "identity", scaled = TRUE,
-  short = unit(0.1, "cm"), mid = unit(0.2, "cm"), long = unit(0.3, "cm"),
-  colour = "black", size = 0.5, linetype = 1, alpha = 1, color = NULL,
-  ticks_per_base = NULL, ...)
+  short = unit(0.1, "cm"), mid = unit(0.2, "cm"), long = unit(0.3,
+  "cm"), colour = "black", size = 0.5, linetype = 1, alpha = 1,
+  color = NULL, ticks_per_base = NULL, ...)
 }
 \arguments{
 \item{sides}{a string that controls which sides of the plot the log ticks appear on.

--- a/man/byte_format.Rd
+++ b/man/byte_format.Rd
@@ -16,7 +16,8 @@ Mb(x)
 
 Gb(x)
 
-bytes(x, symbol = "auto", units = c("binary", "si"), only_highest = FALSE)
+bytes(x, symbol = "auto", units = c("binary", "si"),
+  only_highest = FALSE)
 }
 \arguments{
 \item{symbol}{byte symbol to use. If "\code{auto}" the symbol used will be

--- a/man/geom_bkde.Rd
+++ b/man/geom_bkde.Rd
@@ -11,8 +11,9 @@ geom_bkde(mapping = NULL, data = NULL, stat = "bkde",
 
 stat_bkde(mapping = NULL, data = NULL, geom = "area",
   position = "stack", kernel = "normal", canonical = FALSE,
-  bandwidth = NULL, gridsize = 410, range.x = NULL, truncate = TRUE,
-  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE, ...)
+  bandwidth = NULL, gridsize = 410, range.x = NULL,
+  truncate = TRUE, na.rm = FALSE, show.legend = NA,
+  inherit.aes = TRUE, ...)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
@@ -31,7 +32,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -61,7 +62,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
 \item{geom, stat}{Use to override the default connection between

--- a/man/geom_bkde2d.Rd
+++ b/man/geom_bkde2d.Rd
@@ -7,13 +7,14 @@
 \usage{
 geom_bkde2d(mapping = NULL, data = NULL, stat = "bkde2d",
   position = "identity", bandwidth = NULL, range.x = NULL,
-  lineend = "butt", contour = TRUE, linejoin = "round", linemitre = 1,
-  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE, ...)
+  lineend = "butt", contour = TRUE, linejoin = "round",
+  linemitre = 1, na.rm = FALSE, show.legend = NA,
+  inherit.aes = TRUE, ...)
 
 stat_bkde2d(mapping = NULL, data = NULL, geom = "density2d",
   position = "identity", contour = TRUE, bandwidth = NULL,
-  grid_size = c(51, 51), range.x = NULL, truncate = TRUE, na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE, ...)
+  grid_size = c(51, 51), range.x = NULL, truncate = TRUE,
+  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE, ...)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
@@ -32,7 +33,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{stat}{The statistical transformation to use on the data for this
@@ -75,7 +76,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
 \item{geom}{default geom to use with this stat}

--- a/man/geom_cartogram.Rd
+++ b/man/geom_cartogram.Rd
@@ -4,8 +4,8 @@
 \alias{geom_cartogram}
 \title{Map polygons layer enabling the display of show statistical information}
 \usage{
-geom_cartogram(mapping = NULL, data = NULL, stat = "identity", ..., map,
-  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE)
+geom_cartogram(mapping = NULL, data = NULL, stat = "identity", ...,
+  map, na.rm = FALSE, show.legend = NA, inherit.aes = TRUE)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
@@ -24,7 +24,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{stat}{The statistical transformation to use on the data for this
@@ -32,7 +32,7 @@ layer, as a string.}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
 \item{map}{Data frame that contains the map coordinates.  This will

--- a/man/geom_dumbbell.Rd
+++ b/man/geom_dumbbell.Rd
@@ -27,7 +27,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{...}{other arguments passed on to \code{\link{layer}}. These are

--- a/man/geom_lollipop.Rd
+++ b/man/geom_lollipop.Rd
@@ -25,7 +25,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{...}{other arguments passed on to \code{\link{layer}}. These are

--- a/man/geom_spikelines.Rd
+++ b/man/geom_spikelines.Rd
@@ -26,7 +26,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{stat}{The statistical transformation to use on the data for this
@@ -37,7 +37,7 @@ a call to a position adjustment function.}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
 \item{arrow}{Arrow specification, as created by \code{\link[grid:arrow]{grid::arrow()}}.}

--- a/man/geom_stateface.Rd
+++ b/man/geom_stateface.Rd
@@ -5,9 +5,9 @@
 \title{Use ProPublica's StateFace font in ggplot2 plots}
 \usage{
 geom_stateface(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", ..., parse = FALSE, nudge_x = 0, nudge_y = 0,
-  check_overlap = FALSE, na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE)
+  position = "identity", ..., parse = FALSE, nudge_x = 0,
+  nudge_y = 0, check_overlap = FALSE, na.rm = FALSE,
+  show.legend = NA, inherit.aes = TRUE)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
@@ -26,7 +26,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{stat}{The statistical transformation to use on the data for this
@@ -37,11 +37,11 @@ a call to a position adjustment function.}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
 \item{parse}{If \code{TRUE}, the labels will be parsed into expressions and
-displayed as described in ?plotmath}
+displayed as described in \code{?plotmath}.}
 
 \item{nudge_x, nudge_y}{Horizontal and vertical adjustment to nudge l
 abels by. Useful for offsetting text from points, particularly

--- a/man/geom_ubar.Rd
+++ b/man/geom_ubar.Rd
@@ -25,7 +25,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{stat}{The statistical transformation to use on the data for this

--- a/man/geom_xspline.Rd
+++ b/man/geom_xspline.Rd
@@ -32,7 +32,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{position}{Position adjustment, either as a string, or the result of
@@ -64,7 +64,7 @@ curve. Ignored for closed X-splines.}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
 \item{geom, stat}{Use to override the default connection between

--- a/man/geom_xspline2.Rd
+++ b/man/geom_xspline2.Rd
@@ -26,7 +26,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{stat}{Use to override the default connection between
@@ -51,7 +51,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \value{

--- a/man/position-dodgev.Rd
+++ b/man/position-dodgev.Rd
@@ -4,36 +4,42 @@
 \name{position_dodgev}
 \alias{position_dodgev}
 \alias{PositionDodgev}
-\alias{pos_dodgev}
-\alias{collidev}
 \title{Vertically dodge position}
 \usage{
 position_dodgev(height = NULL)
-
-pos_dodgev(df, height)
-
-collidev(data, height = NULL, name, strategy, ..., check.height = TRUE,
-  reverse = FALSE)
+}
+\arguments{
+\item{height}{numeric, height of vertical dodge, Default: NULL}
 }
 \description{
 Vertically dodge position
 }
 \note{
 position-dodgev(): unmodified from lionel-/ggstance/R/position-dodgev.R 73f521384ae8ea277db5f7d5a2854004aa18f947
+}
+\examples{
 
-PositionDodgev(): based on from lionel-/ggstance/R/position-dodgev.R 73f521384ae8ea277db5f7d5a2854004aa18f947
+if(interactive()){
 
-pos_dodgev(): unmodified from lionel-/ggstance/R/position-dodgev.R 73f521384ae8ea277db5f7d5a2854004aa18f947
+dat <- data.frame(
+  trt = c(LETTERS[1:5], "D"),
+  l = c(20, 40, 10, 30, 50, 40),
+  r = c(70, 50, 30, 60, 80, 70)
+)
 
-collidev(): based on lionel-/ggstance/R/position.R 73f521384ae8ea277db5f7d5a2854004aa18f947
+ggplot(dat, aes(y=trt, x=l, xend=r)) +
+ geom_dumbbell(size=3, color="#e3e2e1",
+               colour_x = "#5b8124", colour_xend = "#bad744",
+               dot_guide=TRUE, dot_guide_size=0.25,
+               position=position_dodgev(height=0.8)) +
+ labs(x=NULL, y=NULL, title="ggplot2 geom_dumbbell with dot guide") +
+ theme_minimal() +
+ theme(panel.grid.major.x=element_line(size=0.05))
+
+ }
+
 }
 \author{
-@ggstance authors
-
-@ggstance authors
-
-@ggstance authors
-
 @ggstance authors
 }
 \keyword{datasets}

--- a/man/stat_ash.Rd
+++ b/man/stat_ash.Rd
@@ -4,9 +4,9 @@
 \alias{stat_ash}
 \title{Compute and display a univariate averaged shifted histogram (polynomial kernel)}
 \usage{
-stat_ash(mapping = NULL, data = NULL, geom = "area", position = "stack",
-  ab = NULL, nbin = 50, m = 5, kopt = c(2, 2), na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE, ...)
+stat_ash(mapping = NULL, data = NULL, geom = "area",
+  position = "stack", ab = NULL, nbin = 50, m = 5, kopt = c(2,
+  2), na.rm = FALSE, show.legend = NA, inherit.aes = TRUE, ...)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
@@ -25,7 +25,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{geom}{Use to override the default Geom}
@@ -61,7 +61,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \description{

--- a/man/stat_stepribbon.Rd
+++ b/man/stat_stepribbon.Rd
@@ -25,7 +25,7 @@ data. All objects will be fortified to produce a data frame. See
 \code{\link[=fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
-the plot data. The return value must be a \code{data.frame.}, and
+the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data.}
 
 \item{geom}{which geom to use; defaults to "\code{ribbon}"}
@@ -52,7 +52,7 @@ vertical-horizontal steps}
 
 \item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \description{


### PR DESCRIPTION
the current `dogedev` docs didn't pass r cmd check wo warnings. updated them and added an example for the help of the fn.

cc @jonocarroll