### PR TITLE
Add accuracy parameter to comma function to fix rounding.

### DIFF
--- a/R/formatters.r
+++ b/R/formatters.r
@@ -72,7 +72,7 @@ bytes <- function (x, symbol = "auto", units = c("binary", "si"),
   if (only_highest) {
     symbol <- max(symbol, na.rm = TRUE)
   }
-  res <- paste(scales::comma(round(x / base^symbol, 1L)),
+  res <- paste(scales::comma(round(x / base^symbol, 1L), accuracy = 0.1),
                out_names[symbol + 1])
   ifelse(!is.na(x), res, x)
 }


### PR DESCRIPTION
I think that the function comma has been changed and now by default number get rounded to the nearest integer. The pull request adds the parameter to restore the original behavior that was to print one decimal digit.
Without PR:
```r
> byte_format()(1.5 * 1024^3)
[1]  "2 Gb"
```
with PR
```r
> byte_format()(1.5 * 1024^3)
[1]  "1.5 Gb"
```