### PR TITLE
Add ndensity computed group stat to StatBkde2d

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Authors@R: c(
       person("Aditya", "Kothari", role=c("aut", "ctb"), comment="Core functionality of horizon plots"),
       person("Ather", role="dtc", comment="Core functionality of horizon plots"),
       person("Jonathan","Sidi", role=c("aut","ctb"), comment="Annotation ticks"),
-      person("Tarcisio","Fedrizzi", role="ctb", comment="Bytes formatter")
+      person("Tarcisio","Fedrizzi", role="ctb", comment="Bytes formatter"),
+      person("Luke", "Smith", role="ctb", comment="Added ndensity to StatBkde2d")
     )
 Description: A compendium of new geometries, coordinate systems, statistical 
     transformations, scales and fonts for 'ggplot2', including splines, 1d and 2d densities, 

--- a/R/geom_bkde2d.r
+++ b/R/geom_bkde2d.r
@@ -185,6 +185,7 @@ StatBkde2d <- ggproto("StatBkde2d", Stat,
       StatContour$compute_panel(df, scales)
     } else {
       names(df) <- c("x", "y", "density", "group")
+      df$ndensity <- df$density/max(df$density, na.rm = TRUE)
       df$level <- 1
       df$piece <- 1
       df


### PR DESCRIPTION
Gives `stat_bkde2d()` the same behavior as `stat_density2d()` -- normalizing the density to the max density per group when facetting.  Similar to the `nlevel` computed stat.

### Before (density)

```r
library(ggplot2)
library(ggalt) # from seasmith/ggalt branch add-ndensity

ggplot(iris, aes(Sepal.Length, Petal.Length)) +
    stat_bkde2d(aes(fill = stat(density)), geom = "raster", contour = FALSE) +
    facet_wrap(vars(Species))
```

![before-ndensity](https://user-images.githubusercontent.com/16291809/60742381-cb546e00-9f32-11e9-8f1d-d98a05fc77a3.png)


### After (ndensity)

```r
ggplot(iris, aes(Sepal.Length, Petal.Length)) +
    stat_bkde2d(aes(fill = stat(ndensity)), geom = "raster", contour = FALSE) +
    facet_wrap(vars(Species))
```

![with-ndensity](https://user-images.githubusercontent.com/16291809/60742341-a233dd80-9f32-11e9-9ae2-f7d4f62946a3.png)

