### PR TITLE
Changed the parent prototype class for GeomXspline

### DIFF
--- a/R/geom_xspline.r
+++ b/R/geom_xspline.r
@@ -148,7 +148,7 @@ geom_xspline <- function(mapping = NULL, data = NULL, stat = "xspline",
 #' @usage NULL
 #' @keywords internal
 #' @export
-GeomXspline <- ggproto("GeomXspline", GeomLine,
+GeomXspline <- ggproto("GeomXspline", GeomPath,
   required_aes = c("x", "y"),
   default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA)
 )


### PR DESCRIPTION
In order to get a similar result as the base graphics `xspline` function, the base proto class has to be a path and not a line.

In most cases there will be no difference, although in all the cases when the order of the control points has not an increasing *x* variable the result with a line will be a jittered output (see bug report #64 for details)

Fixes issue #64 