### PR TITLE
Updates CoordProj to new API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Imports:
     extrafont,
     tibble,
     plotly (>= 3.4.1)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 VignetteBuilder: knitr
 Collate:
     'annotate_textp.r'

--- a/R/coord_proj.r
+++ b/R/coord_proj.r
@@ -101,6 +101,9 @@ coord_proj <- function(proj=NULL, inverse = FALSE, degrees = TRUE,
 #' @keywords internal
 #' @export
 CoordProj <- ggproto("CoordProj", ggplot2::Coord,
+  aspect = function(ranges) {
+    diff(ranges$y.proj) / diff(ranges$x.proj)
+  },
   render_bg = function(self, panel_params, theme) {
     xrange <- expand_range(panel_params$x.range, 0.2)
     yrange <- expand_range(panel_params$y.range, 0.2)

--- a/R/coord_proj.r
+++ b/R/coord_proj.r
@@ -104,6 +104,10 @@ CoordProj <- ggproto("CoordProj", ggplot2::Coord,
   aspect = function(ranges) {
     diff(ranges$y.proj) / diff(ranges$x.proj)
   },
+  distance = function(x, y, panel_params) {
+    max_dist <- dist_central_angle(panel_params$x.range, panel_params$y.range)
+    dist_central_angle(x, y) / max_dist
+  },
   render_bg = function(self, panel_params, theme) {
     xrange <- expand_range(panel_params$x.range, 0.2)
     yrange <- expand_range(panel_params$y.range, 0.2)

--- a/R/coord_proj.r
+++ b/R/coord_proj.r
@@ -42,14 +42,14 @@
 #' @export
 #' @examples \dontrun{
 #' # World in Winkel-Tripel
-# world <- map_data("world")
-# world <- world[world$region != "Antarctica",]
-#
-# gg <- ggplot()
-# gg <- gg + geom_cartogram(data=world, map=world,
-#                     aes(x=long, y=lat, map_id=region))
-# gg <- gg + coord_proj("+proj=wintri")
-# gg
+#' world <- map_data("world")
+#' world <- world[world$region != "Antarctica",]
+#'
+#' gg <- ggplot()
+#' gg <- gg + geom_cartogram(data=world, map=world,
+#'                     aes(x=long, y=lat, map_id=region))
+#' gg <- gg + coord_proj("+proj=wintri")
+#' gg
 #'
 #' # U.S.A. Albers-style
 #' usa <- world[world$region == "USA",]
@@ -100,131 +100,8 @@ coord_proj <- function(proj=NULL, inverse = FALSE, degrees = TRUE,
 #' @usage NULL
 #' @keywords internal
 #' @export
-CoordProj <- ggproto("CoordProj", Coord,
-
-  transform = function(self, data, panel_params) {
-
-    trans <- project4(self, data$x, data$y)
-    out <- cunion(trans[c("x", "y")], data)
-
-    out$x <- rescale(out$x, 0:1, panel_params$x.proj)
-    out$y <- rescale(out$y, 0:1, panel_params$y.proj)
-
-    out
-
-  },
-
-  distance = function(x, y, panel_params) {
-    max_dist <- dist_central_angle(panel_params$x.range, panel_params$y.range)
-    dist_central_angle(x, y) / max_dist
-  },
-
-  aspect = function(ranges) {
-    diff(ranges$y.proj) / diff(ranges$x.proj)
-  },
-
- train = function(self, scale_details) {
-
-    # range in scale
-    ranges <- list()
-    for (n in c("x", "y")) {
-
-      scale <- scale_details[[n]]
-      limits <- self$limits[[n]]
-
-      if (is.null(limits)) {
-        range <- scale$dimension(expand_default(scale))
-      } else {
-        range <- range(scale$transform(limits))
-      }
-      ranges[[n]] <- range
-    }
-
-    orientation <- self$orientation %||% c(90, 0, mean(ranges$x))
-
-    # Increase chances of creating valid boundary region
-    grid <- expand.grid(
-      x = seq(ranges$x[1], ranges$x[2], length.out = 50),
-      y = seq(ranges$y[1], ranges$y[2], length.out = 50)
-    )
-
-    ret <- list(x = list(), y = list())
-
-    # range in map
-    proj <- project4(self, grid$x, grid$y)$range
-    ret$x$proj <- proj[1:2]
-    ret$y$proj <- proj[3:4]
-
-    for (n in c("x", "y")) {
-      out <- scale_details[[n]]$break_info(ranges[[n]])
-      ret[[n]]$range <- out$range
-      ret[[n]]$major <- out$major_source
-      ret[[n]]$minor <- out$minor_source
-      ret[[n]]$labels <- out$labels
-    }
-
-    details <- list(
-      orientation = orientation,
-      x.range = ret$x$range, y.range = ret$y$range,
-      x.proj = ret$x$proj, y.proj = ret$y$proj,
-      x.major = ret$x$major, x.minor = ret$x$minor, x.labels = ret$x$labels,
-      y.major = ret$y$major, y.minor = ret$y$minor, y.labels = ret$y$labels
-    )
-    details
-  },
-  setup_panel_params = function(self, scale_x, scale_y, params = list()) {
-
-    # range in scale
-    ranges <- list()
-    for (n in c("x", "y")) {
-
-      scale <- get(paste0("scale_", n))
-      limits <- self$limits[[n]]
-
-      if (is.null(limits)) {
-        range <- scale$dimension(expand_default(scale))
-      } else {
-        range <- range(scale$transform(limits))
-      }
-      ranges[[n]] <- range
-    }
-
-    orientation <- self$orientation %||% c(90, 0, mean(ranges$x))
-
-    # Increase chances of creating valid boundary region
-    grid <- expand.grid(
-      x = seq(ranges$x[1], ranges$x[2], length.out = 50),
-      y = seq(ranges$y[1], ranges$y[2], length.out = 50)
-    )
-
-    ret <- list(x = list(), y = list())
-
-    # range in map
-    proj <- project4(self, grid$x, grid$y)$range
-    ret$x$proj <- proj[1:2]
-    ret$y$proj <- proj[3:4]
-
-    for (n in c("x", "y")) {
-      out <- get(paste0("scale_", n))$break_info(ranges[[n]])
-      # out <- panel_params[[n]]$break_info(ranges[[n]])
-      ret[[n]]$range <- out$range
-      ret[[n]]$major <- out$major_source
-      ret[[n]]$minor <- out$minor_source
-      ret[[n]]$labels <- out$labels
-    }
-
-    details <- list(
-      orientation = orientation,
-      x.range = ret$x$range, y.range = ret$y$range,
-      x.proj = ret$x$proj, y.proj = ret$y$proj,
-      x.major = ret$x$major, x.minor = ret$x$minor, x.labels = ret$x$labels,
-      y.major = ret$y$major, y.minor = ret$y$minor, y.labels = ret$y$labels
-    )
-    details
-  },
-
+CoordProj <- ggproto("CoordProj", ggplot2::Coord,
   render_bg = function(self, panel_params, theme) {
-
     xrange <- expand_range(panel_params$x.range, 0.2)
     yrange <- expand_range(panel_params$y.range, 0.2)
 
@@ -318,8 +195,73 @@ CoordProj <- ggproto("CoordProj", Coord,
     )
     axes[[which(arrange == "secondary")]] <- zeroGrob()
     axes
-  }
+  },
 
+  backtransform_range = function(panel_params) {
+    list(x = panel_params$x.range, y = panel_params$y.range)
+  },
+
+  transform = function(self, data, panel_params) {
+
+    trans <- project4(self, data$x, data$y)
+    out <- cunion(trans[c("x", "y")], data)
+
+    out$x <- rescale(out$x, 0:1, panel_params$x.proj)
+    out$y <- rescale(out$y, 0:1, panel_params$y.proj)
+
+    out
+
+  },
+
+  setup_panel_params = function(self, scale_x, scale_y, params = list()) {
+    # range in scale
+    ranges <- list()
+    for (n in c("x", "y")) {
+
+      scale <- get(paste0("scale_", n))
+      limits <- self$limits[[n]]
+
+      if (is.null(limits)) {
+        range <- scale$dimension(expand_default(scale))
+      } else {
+        range <- range(scale$transform(limits))
+      }
+      ranges[[n]] <- range
+    }
+
+    orientation <- self$orientation %||% c(90, 0, mean(ranges$x))
+
+    # Increase chances of creating valid boundary region
+    grid <- expand.grid(
+      x = seq(ranges$x[1], ranges$x[2], length.out = 50),
+      y = seq(ranges$y[1], ranges$y[2], length.out = 50)
+    )
+
+    ret <- list(x = list(), y = list())
+
+    # range in map
+    proj <- project4(self, grid$x, grid$y)$range
+    ret$x$proj <- proj[1:2]
+    ret$y$proj <- proj[3:4]
+
+    for (n in c("x", "y")) {
+      out <- get(paste0("scale_", n))$break_info(ranges[[n]])
+      # out <- panel_params[[n]]$break_info(ranges[[n]])
+      ret[[n]]$range <- out$range
+      ret[[n]]$major <- out$major_source
+      ret[[n]]$minor <- out$minor_source
+      ret[[n]]$labels <- out$labels
+    }
+
+    details <- list(
+      orientation = orientation,
+      x.range = ret$x$range, y.range = ret$y$range,
+      x.proj = ret$x$proj, y.proj = ret$y$proj,
+      x.major = ret$x$major, x.minor = ret$x$minor, x.labels = ret$x$labels,
+      y.major = ret$y$major, y.minor = ret$y$minor, y.labels = ret$y$labels
+    )
+    details
+  }
 )
 
 

--- a/R/guide_axis.r
+++ b/R/guide_axis.r
@@ -42,9 +42,9 @@ guide_axis <- function(at, labels, position = "right", theme) {
 
   labels <- switch(position,
     top = ,
-    bottom = element_render(theme, label_render, labels, x = label_x, expand_y = TRUE),
+    bottom = element_render(theme, label_render, labels, x = label_x),
     right = ,
-    left =  element_render(theme, label_render, labels, y = label_y, expand_x = TRUE))
+    left =  element_render(theme, label_render, labels, y = label_y))
 
   line <- switch(position,
     top =    element_render(theme, "axis.line.x", c(0, 1), c(0, 0), id.lengths = 2),

--- a/man/absoluteGrob.Rd
+++ b/man/absoluteGrob.Rd
@@ -4,8 +4,14 @@
 \alias{absoluteGrob}
 \title{Absolute grob}
 \usage{
-absoluteGrob(grob, width = NULL, height = NULL, xmin = NULL,
-  ymin = NULL, vp = NULL)
+absoluteGrob(
+  grob,
+  width = NULL,
+  height = NULL,
+  xmin = NULL,
+  ymin = NULL,
+  vp = NULL
+)
 }
 \description{
 This grob has fixed dimensions and position.

--- a/man/annotate_textp.Rd
+++ b/man/annotate_textp.Rd
@@ -4,10 +4,22 @@
 \alias{annotate_textp}
 \title{Text annotations in plot coordinate system}
 \usage{
-annotate_textp(label, x, y, facets = NULL, hjust = 0, vjust = 0,
-  color = "black", alpha = NA, family = theme_get()$text$family,
-  size = theme_get()$text$size, fontface = 1, lineheight = 1,
-  box_just = ifelse(c(x, y) < 0.5, 0, 1), margin = unit(size/2, "pt"))
+annotate_textp(
+  label,
+  x,
+  y,
+  facets = NULL,
+  hjust = 0,
+  vjust = 0,
+  color = "black",
+  alpha = NA,
+  family = theme_get()$text$family,
+  size = theme_get()$text$size,
+  fontface = 1,
+  lineheight = 1,
+  box_just = ifelse(c(x, y) < 0.5, 0, 1),
+  margin = unit(size/2, "pt")
+)
 }
 \arguments{
 \item{label}{text annotation to be placed on the plot}
@@ -39,5 +51,5 @@ instead of data coordinates.
 \examples{
 p <- ggplot(mtcars, aes(x = wt, y = mpg)) + geom_point()
 p <- p + geom_smooth(method = "lm", se = FALSE)
-p + annotate_textp(x = 0.9, y = 0.35, label="A relative linear\\nrelationship", hjust=1, color="red")
+p + annotate_textp(x = 0.9, y = 0.35, label="A relative linear\nrelationship", hjust=1, color="red")
 }

--- a/man/annotation_ticks.Rd
+++ b/man/annotation_ticks.Rd
@@ -4,10 +4,21 @@
 \alias{annotation_ticks}
 \title{Annotation: tick marks}
 \usage{
-annotation_ticks(sides = "b", scale = "identity", scaled = TRUE,
-  short = unit(0.1, "cm"), mid = unit(0.2, "cm"), long = unit(0.3,
-  "cm"), colour = "black", size = 0.5, linetype = 1, alpha = 1,
-  color = NULL, ticks_per_base = NULL, ...)
+annotation_ticks(
+  sides = "b",
+  scale = "identity",
+  scaled = TRUE,
+  short = unit(0.1, "cm"),
+  mid = unit(0.2, "cm"),
+  long = unit(0.3, "cm"),
+  colour = "black",
+  size = 0.5,
+  linetype = 1,
+  alpha = 1,
+  color = NULL,
+  ticks_per_base = NULL,
+  ...
+)
 }
 \arguments{
 \item{sides}{a string that controls which sides of the plot the log ticks appear on.

--- a/man/byte_format.Rd
+++ b/man/byte_format.Rd
@@ -16,8 +16,7 @@ Mb(x)
 
 Gb(x)
 
-bytes(x, symbol = "auto", units = c("binary", "si"),
-  only_highest = FALSE)
+bytes(x, symbol = "auto", units = c("binary", "si"), only_highest = FALSE)
 }
 \arguments{
 \item{symbol}{byte symbol to use. If "\code{auto}" the symbol used will be

--- a/man/coord_proj.Rd
+++ b/man/coord_proj.Rd
@@ -5,8 +5,14 @@
 \title{Similar to \code{coord_map} but uses the PROJ.4 library/package for projection
 transformation}
 \usage{
-coord_proj(proj = NULL, inverse = FALSE, degrees = TRUE,
-  ellps.default = "sphere", xlim = NULL, ylim = NULL)
+coord_proj(
+  proj = NULL,
+  inverse = FALSE,
+  degrees = TRUE,
+  ellps.default = "sphere",
+  xlim = NULL,
+  ylim = NULL
+)
 }
 \arguments{
 \item{proj}{projection definition. If left \code{NULL} will default to
@@ -61,6 +67,14 @@ When \code{inverse} is \code{FALSE} \code{coord_proj} makes a fairly
 \examples{
 \dontrun{
 # World in Winkel-Tripel
+world <- map_data("world")
+world <- world[world$region != "Antarctica",]
+
+gg <- ggplot()
+gg <- gg + geom_cartogram(data=world, map=world,
+                    aes(x=long, y=lat, map_id=region))
+gg <- gg + coord_proj("+proj=wintri")
+gg
 
 # U.S.A. Albers-style
 usa <- world[world$region == "USA",]

--- a/man/geom_bkde.Rd
+++ b/man/geom_bkde.Rd
@@ -5,19 +5,39 @@
 \alias{stat_bkde}
 \title{Display a smooth density estimate.}
 \usage{
-geom_bkde(mapping = NULL, data = NULL, stat = "bkde",
-  position = "identity", bandwidth = NULL, range.x = NULL,
-  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE, ...)
+geom_bkde(
+  mapping = NULL,
+  data = NULL,
+  stat = "bkde",
+  position = "identity",
+  bandwidth = NULL,
+  range.x = NULL,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  ...
+)
 
-stat_bkde(mapping = NULL, data = NULL, geom = "area",
-  position = "stack", kernel = "normal", canonical = FALSE,
-  bandwidth = NULL, gridsize = 410, range.x = NULL,
-  truncate = TRUE, na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE, ...)
+stat_bkde(
+  mapping = NULL,
+  data = NULL,
+  geom = "area",
+  position = "stack",
+  kernel = "normal",
+  canonical = FALSE,
+  bandwidth = NULL,
+  gridsize = 410,
+  range.x = NULL,
+  truncate = TRUE,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -25,15 +45,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
@@ -58,9 +79,9 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}

--- a/man/geom_bkde2d.Rd
+++ b/man/geom_bkde2d.Rd
@@ -5,20 +5,42 @@
 \alias{stat_bkde2d}
 \title{Contours from a 2d density estimate.}
 \usage{
-geom_bkde2d(mapping = NULL, data = NULL, stat = "bkde2d",
-  position = "identity", bandwidth = NULL, range.x = NULL,
-  lineend = "butt", contour = TRUE, linejoin = "round",
-  linemitre = 1, na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE, ...)
+geom_bkde2d(
+  mapping = NULL,
+  data = NULL,
+  stat = "bkde2d",
+  position = "identity",
+  bandwidth = NULL,
+  range.x = NULL,
+  lineend = "butt",
+  contour = TRUE,
+  linejoin = "round",
+  linemitre = 1,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  ...
+)
 
-stat_bkde2d(mapping = NULL, data = NULL, geom = "density2d",
-  position = "identity", contour = TRUE, bandwidth = NULL,
-  grid_size = c(51, 51), range.x = NULL, truncate = TRUE,
-  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE, ...)
+stat_bkde2d(
+  mapping = NULL,
+  data = NULL,
+  geom = "density2d",
+  position = "identity",
+  contour = TRUE,
+  bandwidth = NULL,
+  grid_size = c(51, 51),
+  range.x = NULL,
+  truncate = TRUE,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -26,15 +48,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
 layer, as a string.}
@@ -72,9 +95,9 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}

--- a/man/geom_cartogram.Rd
+++ b/man/geom_cartogram.Rd
@@ -4,12 +4,20 @@
 \alias{geom_cartogram}
 \title{Map polygons layer enabling the display of show statistical information}
 \usage{
-geom_cartogram(mapping = NULL, data = NULL, stat = "identity", ...,
-  map, na.rm = FALSE, show.legend = NA, inherit.aes = TRUE)
+geom_cartogram(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  ...,
+  map,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -17,20 +25,21 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
 layer, as a string.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
@@ -52,7 +61,7 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 }
 \description{
 This replicates the old behaviour of \code{geom_map()}, enabling specifying of

--- a/man/geom_dumbbell.Rd
+++ b/man/geom_dumbbell.Rd
@@ -4,15 +4,26 @@
 \alias{geom_dumbbell}
 \title{Dumbbell charts}
 \usage{
-geom_dumbbell(mapping = NULL, data = NULL, ..., colour_x = NULL,
-  size_x = NULL, colour_xend = NULL, size_xend = NULL,
-  dot_guide = FALSE, dot_guide_size = NULL, dot_guide_colour = NULL,
-  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE,
-  position = "identity")
+geom_dumbbell(
+  mapping = NULL,
+  data = NULL,
+  ...,
+  colour_x = NULL,
+  size_x = NULL,
+  colour_xend = NULL,
+  size_xend = NULL,
+  dot_guide = FALSE,
+  dot_guide_size = NULL,
+  dot_guide_colour = NULL,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  position = "identity"
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -20,15 +31,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{...}{other arguments passed on to \code{\link{layer}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
@@ -59,7 +71,7 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{position}{Position adjustment, either as a string, or the result of a
 call to a position adjustment function.}

--- a/man/geom_encircle.Rd
+++ b/man/geom_encircle.Rd
@@ -4,9 +4,16 @@
 \alias{geom_encircle}
 \title{Automatically enclose points in a polygon}
 \usage{
-geom_encircle(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE, ...)
+geom_encircle(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  ...
+)
 }
 \arguments{
 \item{mapping}{mapping}

--- a/man/geom_horizon.Rd
+++ b/man/geom_horizon.Rd
@@ -7,16 +7,34 @@
 \alias{stat_horizon}
 \alias{StatHorizon}
 \title{Plot a time series as a horizon plot}
-\format{An object of class \code{GeomHorizon} (inherits from \code{GeomArea}, \code{GeomRibbon}, \code{Geom}, \code{ggproto}, \code{gg}) of length 4.}
+\format{
+An object of class \code{GeomHorizon} (inherits from \code{GeomArea}, \code{GeomRibbon}, \code{Geom}, \code{ggproto}, \code{gg}) of length 4.
+
+An object of class \code{StatHorizon} (inherits from \code{Stat}, \code{ggproto}, \code{gg}) of length 5.
+}
 \usage{
-geom_horizon(mapping = NULL, data = NULL, show.legend = TRUE,
-  inherit.aes = TRUE, na.rm = TRUE, bandwidth = NULL, ...)
+geom_horizon(
+  mapping = NULL,
+  data = NULL,
+  show.legend = TRUE,
+  inherit.aes = TRUE,
+  na.rm = TRUE,
+  bandwidth = NULL,
+  ...
+)
 
 GeomHorizon
 
-stat_horizon(mapping = NULL, data = NULL, geom = "horizon",
-  show.legend = TRUE, inherit.aes = TRUE, na.rm = TRUE,
-  bandwidth = NULL, ...)
+stat_horizon(
+  mapping = NULL,
+  data = NULL,
+  geom = "horizon",
+  show.legend = TRUE,
+  inherit.aes = TRUE,
+  na.rm = TRUE,
+  bandwidth = NULL,
+  ...
+)
 
 StatHorizon
 }

--- a/man/geom_lollipop.Rd
+++ b/man/geom_lollipop.Rd
@@ -4,13 +4,21 @@
 \alias{geom_lollipop}
 \title{Lollipop charts}
 \usage{
-geom_lollipop(mapping = NULL, data = NULL, ..., horizontal = FALSE,
-  point.colour = NULL, point.size = NULL, na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE)
+geom_lollipop(
+  mapping = NULL,
+  data = NULL,
+  ...,
+  horizontal = FALSE,
+  point.colour = NULL,
+  point.size = NULL,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -18,15 +26,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{...}{other arguments passed on to \code{\link{layer}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
@@ -56,7 +65,7 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 }
 \description{
 The lollipop geom is used to create lollipop charts.

--- a/man/geom_spikelines.Rd
+++ b/man/geom_spikelines.Rd
@@ -4,14 +4,23 @@
 \alias{geom_spikelines}
 \title{Draw spikelines on a plot}
 \usage{
-geom_spikelines(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", ..., arrow = NULL, lineend = "butt",
-  linejoin = "round", na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE)
+geom_spikelines(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  ...,
+  arrow = NULL,
+  lineend = "butt",
+  linejoin = "round",
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -19,15 +28,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
 layer, as a string.}
@@ -35,7 +45,7 @@ layer, as a string.}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
@@ -58,7 +68,7 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 }
 \description{
 Segment reference lines that originate at an point

--- a/man/geom_stateface.Rd
+++ b/man/geom_stateface.Rd
@@ -4,14 +4,24 @@
 \alias{geom_stateface}
 \title{Use ProPublica's StateFace font in ggplot2 plots}
 \usage{
-geom_stateface(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", ..., parse = FALSE, nudge_x = 0,
-  nudge_y = 0, check_overlap = FALSE, na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE)
+geom_stateface(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  ...,
+  parse = FALSE,
+  nudge_x = 0,
+  nudge_y = 0,
+  check_overlap = FALSE,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -19,15 +29,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
 layer, as a string.}
@@ -35,7 +46,7 @@ layer, as a string.}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
@@ -62,7 +73,7 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 }
 \description{
 The \code{label} parameter can be either a 2-letter state abbreviation
@@ -113,7 +124,8 @@ gg
 }
 }
 \seealso{
-Other StateFace operations: \code{\link{load_stateface}},
-  \code{\link{show_stateface}}
+Other StateFace operations: 
+\code{\link{load_stateface}()},
+\code{\link{show_stateface}()}
 }
 \concept{StateFace operations}

--- a/man/geom_ubar.Rd
+++ b/man/geom_ubar.Rd
@@ -4,13 +4,20 @@
 \alias{geom_ubar}
 \title{Uniform "bar" charts}
 \usage{
-geom_ubar(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", ..., na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE)
+geom_ubar(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  ...,
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -18,15 +25,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
 layer, as a string.}
@@ -51,7 +59,7 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 }
 \description{
 I've been using \code{geom_segment} more to make "bar" charts, setting

--- a/man/geom_xspline.Rd
+++ b/man/geom_xspline.Rd
@@ -5,19 +5,37 @@
 \alias{stat_xspline}
 \title{Connect control points/observations with an X-spline}
 \usage{
-geom_xspline(mapping = NULL, data = NULL, stat = "xspline",
-  position = "identity", na.rm = TRUE, show.legend = NA,
-  inherit.aes = TRUE, spline_shape = -0.25, open = TRUE,
-  rep_ends = TRUE, ...)
+geom_xspline(
+  mapping = NULL,
+  data = NULL,
+  stat = "xspline",
+  position = "identity",
+  na.rm = TRUE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  spline_shape = -0.25,
+  open = TRUE,
+  rep_ends = TRUE,
+  ...
+)
 
-stat_xspline(mapping = NULL, data = NULL, geom = "line",
-  position = "identity", na.rm = TRUE, show.legend = NA,
-  inherit.aes = TRUE, spline_shape = -0.25, open = TRUE,
-  rep_ends = TRUE, ...)
+stat_xspline(
+  mapping = NULL,
+  data = NULL,
+  geom = "line",
+  position = "identity",
+  na.rm = TRUE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  spline_shape = -0.25,
+  open = TRUE,
+  rep_ends = TRUE,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -25,15 +43,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
@@ -50,7 +69,7 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{spline_shape}{A numeric vector of values between -1 and 1, which
 control the shape of the spline relative to the control points.}
@@ -62,7 +81,7 @@ closed shape.}
 first and last control points should be replicated for drawing the
 curve. Ignored for closed X-splines.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
@@ -193,6 +212,7 @@ Blanc, C. and Schlick, C. (1995), "X-splines : A Spline Model
  \code{\link[graphics]{xspline}};
  \code{\link[grid]{grid.xspline}}
 
-Other xspline implementations: \code{\link{geom_xspline2}}
+Other xspline implementations: 
+\code{\link{geom_xspline2}()}
 }
 \concept{xspline implementations}

--- a/man/geom_xspline2.Rd
+++ b/man/geom_xspline2.Rd
@@ -5,13 +5,20 @@
 \title{Alternative implemenation for connecting  control points/observations
 with an X-spline}
 \usage{
-geom_xspline2(mapping = NULL, data = NULL, stat = "identity",
-  position = "identity", na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE, ...)
+geom_xspline2(
+  mapping = NULL,
+  data = NULL,
+  stat = "identity",
+  position = "identity",
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -19,15 +26,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{Use to override the default connection between
 \code{geom_xspline} and \code{stat_xspline}.}
@@ -47,9 +55,9 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
@@ -62,7 +70,8 @@ Alternative implemenation for connecting  control points/observations
 with an X-spline
 }
 \seealso{
-Other xspline implementations: \code{\link{geom_xspline}}
+Other xspline implementations: 
+\code{\link{geom_xspline}()}
 }
 \author{
 Ben Bolker

--- a/man/ggalt.Rd
+++ b/man/ggalt.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{ggalt}
 \alias{ggalt}
-\alias{ggalt-package}
 \title{Extra Geoms, Stats, Coords, Scales & Fonts for 'ggplot2'}
 \description{
 A package containing additional geoms, coords, stats, scales & fonts

--- a/man/load_stateface.Rd
+++ b/man/load_stateface.Rd
@@ -11,7 +11,8 @@ Makes the ProPublica StateFace font available to PDF, PostScript,
 et. al. devices.
 }
 \seealso{
-Other StateFace operations: \code{\link{geom_stateface}},
-  \code{\link{show_stateface}}
+Other StateFace operations: 
+\code{\link{geom_stateface}()},
+\code{\link{show_stateface}()}
 }
 \concept{StateFace operations}

--- a/man/show_stateface.Rd
+++ b/man/show_stateface.Rd
@@ -12,7 +12,8 @@ in the on-screen plot device for ggplot2, you need to install
 the font on your system
 }
 \seealso{
-Other StateFace operations: \code{\link{geom_stateface}},
-  \code{\link{load_stateface}}
+Other StateFace operations: 
+\code{\link{geom_stateface}()},
+\code{\link{load_stateface}()}
 }
 \concept{StateFace operations}

--- a/man/stat_ash.Rd
+++ b/man/stat_ash.Rd
@@ -4,13 +4,24 @@
 \alias{stat_ash}
 \title{Compute and display a univariate averaged shifted histogram (polynomial kernel)}
 \usage{
-stat_ash(mapping = NULL, data = NULL, geom = "area",
-  position = "stack", ab = NULL, nbin = 50, m = 5, kopt = c(2,
-  2), na.rm = FALSE, show.legend = NA, inherit.aes = TRUE, ...)
+stat_ash(
+  mapping = NULL,
+  data = NULL,
+  geom = "area",
+  position = "stack",
+  ab = NULL,
+  nbin = 50,
+  m = 5,
+  kopt = c(2, 2),
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -18,15 +29,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{geom}{Use to override the default Geom}
 
@@ -57,9 +69,9 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}

--- a/man/stat_stepribbon.Rd
+++ b/man/stat_stepribbon.Rd
@@ -4,13 +4,21 @@
 \alias{stat_stepribbon}
 \title{Step ribbon statistic}
 \usage{
-stat_stepribbon(mapping = NULL, data = NULL, geom = "ribbon",
-  position = "identity", na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE, direction = "hv", ...)
+stat_stepribbon(
+  mapping = NULL,
+  data = NULL,
+  geom = "ribbon",
+  position = "identity",
+  na.rm = FALSE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  direction = "hv",
+  ...
+)
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
-\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
+\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
 default), it is combined with the default mapping at the top level of the
 plot. You must supply \code{mapping} if there is no plot mapping.}
 
@@ -18,15 +26,16 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 options:
 
 If \code{NULL}, the default, the data is inherited from the plot
-data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+data as specified in the call to \code{\link[ggplot2:ggplot]{ggplot()}}.
 
 A \code{data.frame}, or other object, will override the plot
 data. All objects will be fortified to produce a data frame. See
-\code{\link[=fortify]{fortify()}} for which variables will be created.
+\code{\link[ggplot2:fortify]{fortify()}} for which variables will be created.
 
 A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
-will be used as the layer data.}
+will be used as the layer data. A \code{function} can be created
+from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{geom}{which geom to use; defaults to "\code{ribbon}"}
 
@@ -45,12 +54,12 @@ display.}
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 
 \item{direction}{\code{hv} for horizontal-veritcal steps, \code{vh} for
 vertical-horizontal steps}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}


### PR DESCRIPTION
This is an attempt to update CoordProj to the current ggplot2 Coord extension API (#62 ). I don't know if it's correct, but at least the examples do run. 

``` r
library(ggplot2)
library(ggalt)
#> Registered S3 methods overwritten by 'ggalt':
#>   method                  from   
#>   grid.draw.absoluteGrob  ggplot2
#>   grobHeight.absoluteGrob ggplot2
#>   grobWidth.absoluteGrob  ggplot2
#>   grobX.absoluteGrob      ggplot2
#>   grobY.absoluteGrob      ggplot2

world <- map_data("world")
world <- world[world$region != "Antarctica",]

gg <- ggplot()
gg <- gg + geom_cartogram(data=world, map=world,
                    aes(x=long, y=lat, map_id=region))
gg <- gg + coord_proj("+proj=wintri")
gg
```

![](https://i.imgur.com/0XUnBRu.png)

``` r

# U.S.A. Albers-style
usa <- world[world$region == "USA",]
usa <- usa[!(usa$subregion %in% c("Alaska", "Hawaii")),]

gg <- ggplot()
gg <- gg + geom_cartogram(data=usa, map=usa,
                    aes(x=long, y=lat, map_id=region))
gg <- gg + coord_proj(
             paste0("+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=37.5 +lon_0=-96",
                    " +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs"))
gg
```

![](https://i.imgur.com/WZXvODJ.png)

``` r

# Showcase Greenland (properly)
greenland <- world[world$region == "Greenland",]

gg <- ggplot()
gg <- gg + geom_cartogram(data=greenland, map=greenland,
                    aes(x=long, y=lat, map_id=region))
gg <- gg + coord_proj(
             paste0("+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0",
                    " +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"))
gg
```

![](https://i.imgur.com/EIxqRkj.png)

<sup>Created on 2020-04-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

<details>

<summary>Session info</summary>

``` r
devtools::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                         
#>  version  R version 3.6.3 (2020-02-29)  
#>  os       elementary OS 5.1.3 Hera      
#>  system   x86_64, linux-gnu             
#>  ui       X11                           
#>  language en_US                         
#>  collate  en_US.UTF-8                   
#>  ctype    en_US.UTF-8                   
#>  tz       America/Argentina/Buenos_Aires
#>  date     2020-04-17                    
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package      * version    date       lib source                   
#>  ash            1.0-15     2015-09-01 [1] CRAN (R 3.6.0)           
#>  assertthat     0.2.1      2019-03-21 [1] CRAN (R 3.6.0)           
#>  backports      1.1.5      2019-10-02 [1] CRAN (R 3.6.1)           
#>  callr          3.4.2      2020-02-12 [1] CRAN (R 3.6.2)           
#>  cli            2.0.2      2020-02-28 [1] CRAN (R 3.6.3)           
#>  colorspace     1.4-1      2019-03-18 [1] CRAN (R 3.6.0)           
#>  crayon         1.3.4      2017-09-16 [1] CRAN (R 3.6.2)           
#>  curl           4.3        2019-12-02 [1] CRAN (R 3.6.2)           
#>  desc           1.2.0      2018-05-01 [1] CRAN (R 3.6.0)           
#>  devtools       2.2.2      2020-02-17 [1] CRAN (R 3.6.3)           
#>  digest         0.6.25     2020-02-23 [1] CRAN (R 3.6.3)           
#>  dplyr          0.8.5      2020-03-07 [1] CRAN (R 3.6.3)           
#>  ellipsis       0.3.0      2019-09-20 [1] CRAN (R 3.6.1)           
#>  evaluate       0.14       2019-05-28 [1] CRAN (R 3.6.0)           
#>  extrafont      0.17       2014-12-08 [1] CRAN (R 3.6.0)           
#>  extrafontdb    1.0        2012-06-11 [1] CRAN (R 3.6.0)           
#>  fansi          0.4.1      2020-01-08 [1] CRAN (R 3.6.2)           
#>  farver         2.0.3      2020-01-16 [1] CRAN (R 3.6.2)           
#>  fs             1.3.2      2020-03-05 [1] CRAN (R 3.6.3)           
#>  ggalt        * 0.6.2      2020-04-17 [1] local                    
#>  ggplot2      * 3.3.0      2020-03-05 [1] CRAN (R 3.6.3)           
#>  glue           1.3.2      2020-03-12 [1] CRAN (R 3.6.3)           
#>  gtable         0.3.0      2019-03-25 [1] CRAN (R 3.6.0)           
#>  highr          0.8        2019-03-20 [1] CRAN (R 3.6.0)           
#>  htmltools      0.4.0      2019-10-04 [1] CRAN (R 3.6.1)           
#>  httr           1.4.1      2019-08-05 [1] CRAN (R 3.6.1)           
#>  KernSmooth     2.23-16    2019-10-15 [4] CRAN (R 3.6.1)           
#>  knitr          1.28       2020-02-06 [1] CRAN (R 3.6.2)           
#>  labeling       0.3        2014-08-23 [1] CRAN (R 3.6.0)           
#>  lifecycle      0.2.0      2020-03-06 [1] CRAN (R 3.6.3)           
#>  magrittr       1.5        2014-11-22 [1] CRAN (R 3.6.0)           
#>  maps           3.3.0      2018-04-03 [1] CRAN (R 3.6.3)           
#>  MASS           7.3-51.5   2019-12-20 [4] CRAN (R 3.6.2)           
#>  memoise        1.1.0      2017-04-21 [1] CRAN (R 3.6.0)           
#>  mime           0.9        2020-02-04 [1] CRAN (R 3.6.2)           
#>  munsell        0.5.0      2018-06-12 [1] CRAN (R 3.6.0)           
#>  pillar         1.4.3      2019-12-20 [1] CRAN (R 3.6.2)           
#>  pkgbuild       1.0.6      2019-10-09 [1] CRAN (R 3.6.2)           
#>  pkgconfig      2.0.3      2019-09-22 [1] CRAN (R 3.6.1)           
#>  pkgload        1.0.2      2018-10-29 [1] CRAN (R 3.6.0)           
#>  prettyunits    1.1.1      2020-01-24 [1] CRAN (R 3.6.2)           
#>  processx       3.4.2      2020-02-09 [1] CRAN (R 3.6.2)           
#>  proj4          1.0-10     2020-03-02 [1] CRAN (R 3.6.3)           
#>  ps             1.3.2      2020-02-13 [1] CRAN (R 3.6.2)           
#>  purrr          0.3.3      2019-10-18 [1] CRAN (R 3.6.2)           
#>  R6             2.4.1.9000 2020-01-21 [1] Github (r-lib/R6@8e0b318)
#>  RColorBrewer   1.1-2      2014-12-07 [1] CRAN (R 3.6.0)           
#>  Rcpp           1.0.4      2020-03-17 [1] CRAN (R 3.6.3)           
#>  remotes        2.1.1      2020-02-15 [1] CRAN (R 3.6.3)           
#>  rlang          0.4.5      2020-03-01 [1] CRAN (R 3.6.3)           
#>  rmarkdown      2.1        2020-01-20 [1] CRAN (R 3.6.2)           
#>  rprojroot      1.3-2      2018-01-03 [1] CRAN (R 3.6.0)           
#>  Rttf2pt1       1.3.8      2020-01-10 [1] CRAN (R 3.6.2)           
#>  scales         1.1.0      2019-11-18 [1] CRAN (R 3.6.2)           
#>  sessioninfo    1.1.1      2018-11-05 [1] CRAN (R 3.6.0)           
#>  stringi        1.4.6      2020-02-17 [1] CRAN (R 3.6.3)           
#>  stringr        1.4.0      2019-02-10 [1] CRAN (R 3.6.0)           
#>  testthat       2.3.2      2020-03-02 [1] CRAN (R 3.6.3)           
#>  tibble         2.1.3      2019-06-06 [1] CRAN (R 3.6.0)           
#>  tidyselect     1.0.0      2020-01-27 [1] CRAN (R 3.6.2)           
#>  usethis        1.5.1      2019-07-04 [1] CRAN (R 3.6.1)           
#>  withr          2.1.2      2018-03-15 [1] CRAN (R 3.6.0)           
#>  xfun           0.12       2020-01-13 [1] CRAN (R 3.6.2)           
#>  xml2           1.2.5      2020-03-11 [1] CRAN (R 3.6.3)           
#>  yaml           2.2.1      2020-02-01 [1] CRAN (R 3.6.2)           
#> 
#> [1] /home/elio/R/x86_64-pc-linux-gnu-library/3.6
#> [2] /usr/local/lib/R/site-library
#> [3] /usr/lib/R/site-library
#> [4] /usr/lib/R/library
```

</details>